### PR TITLE
#13 Fix MemberSts Change StatusType

### DIFF
--- a/src/main/java/com/dj/server/api/member/entity/Member.java
+++ b/src/main/java/com/dj/server/api/member/entity/Member.java
@@ -2,14 +2,15 @@ package com.dj.server.api.member.entity;
 
 import com.dj.server.api.member.entity.enums.MemberRole;
 import com.dj.server.api.member.entity.enums.SocialType;
+import com.dj.server.api.member.entity.enums.StatusType;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.hibernate.annotations.ColumnDefault;
-import org.hibernate.annotations.CreationTimestamp;
-import org.hibernate.annotations.UpdateTimestamp;
+import org.hibernate.annotations.*;
 
 import javax.persistence.*;
+import javax.persistence.Entity;
+import javax.persistence.Table;
 import javax.validation.constraints.NotNull;
 import java.time.LocalDateTime;
 
@@ -24,6 +25,7 @@ import java.time.LocalDateTime;
 
 @Getter
 @NoArgsConstructor
+@DynamicUpdate
 @Table
 @Entity
 public class Member {
@@ -41,11 +43,11 @@ public class Member {
     private String memberNickName;
 
     @NotNull
-    @ColumnDefault("0")
+    @Enumerated(EnumType.STRING)
     @Column
-    private boolean memberSts;
+    private StatusType memberSts;
 
-    @Column(length = 200)
+    @Column(length = 200, insertable = false)
     private String refreshToken;
 
     @NotNull
@@ -53,6 +55,7 @@ public class Member {
     @Column
     private MemberRole memberRole;
 
+    @NotNull
     @Column
     @Enumerated(EnumType.STRING)
     private SocialType socialType;
@@ -69,13 +72,15 @@ public class Member {
     private String memberName;
 
     @Builder
-    public Member(String memberSnsId, String memberNickName, MemberRole memberRole, SocialType socialType, String memberName) {
+    public Member(String memberSnsId, String memberNickName, StatusType memberSts, MemberRole memberRole, SocialType socialType, String memberName) {
         this.memberSnsId = memberSnsId;
         this.memberNickName = memberNickName;
+        this.memberSts = memberSts;
         this.memberRole = memberRole;
         this.socialType = socialType;
         this.memberName = memberName;
     }
+
 
     public void updateNickName(String nickName) {
         this.memberNickName = nickName;
@@ -86,9 +91,8 @@ public class Member {
         return this;
     }
 
-    public Member saveRefreshToken(String refreshToken) {
+    public void saveRefreshToken(String refreshToken) {
         this.refreshToken = refreshToken;
-        return this;
     }
 
 }

--- a/src/main/java/com/dj/server/api/member/entity/enums/SocialType.java
+++ b/src/main/java/com/dj/server/api/member/entity/enums/SocialType.java
@@ -1,6 +1,7 @@
 package com.dj.server.api.member.entity.enums;
 
 import lombok.Getter;
+import lombok.RequiredArgsConstructor;
 
 /**
  * Member가 어떤 Oauth2 소셜인증을 통해서
@@ -11,13 +12,11 @@ import lombok.Getter;
  * @since 0.0.1
  */
 @Getter
+@RequiredArgsConstructor
 public enum SocialType {
     GOOGLE("google"),
     KAKAO("kakao");
 
     private final String name;
 
-    SocialType(String name) {
-        this.name = name;
-    }
 }

--- a/src/main/java/com/dj/server/api/member/entity/enums/StatusType.java
+++ b/src/main/java/com/dj/server/api/member/entity/enums/StatusType.java
@@ -1,0 +1,24 @@
+package com.dj.server.api.member.entity.enums;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+/**
+ *
+ * 회원의 타입을 나타내는 enum 클래스
+ *
+ * @author JaeHyun
+ * @created 2021-08-14
+ * @since 0.0.1
+ */
+
+@Getter
+@RequiredArgsConstructor
+public enum StatusType {
+
+    NORMAL("정상"),
+    BAN("정지");
+
+    private final String status;
+
+}

--- a/src/main/java/com/dj/server/api/member/service/MemberService.java
+++ b/src/main/java/com/dj/server/api/member/service/MemberService.java
@@ -64,6 +64,7 @@ public class MemberService {
      * @param member Database에 저장된 Member 정보
      * @return 서버에서 생성한 액세스 토큰과 리프레시 토큰
      */
+
     private ResponseTokenDTO createToken(Member member) {
 
         jwtUtil.setTokenIngredient(String.valueOf(member.getMemberId()));

--- a/src/main/java/com/dj/server/api/member/service/oauth2/kakao/vo/KakaoProfile.java
+++ b/src/main/java/com/dj/server/api/member/service/oauth2/kakao/vo/KakaoProfile.java
@@ -3,6 +3,7 @@ package com.dj.server.api.member.service.oauth2.kakao.vo;
 import com.dj.server.api.member.entity.Member;
 import com.dj.server.api.member.entity.enums.MemberRole;
 import com.dj.server.api.member.entity.enums.SocialType;
+import com.dj.server.api.member.entity.enums.StatusType;
 import lombok.*;
 
 /**
@@ -38,6 +39,7 @@ public class KakaoProfile {
                 .memberSnsId(String.valueOf(id))
                 .memberNickName(kakao_account.getProfile().getNickname())
                 .memberName(kakao_account.getProfile().getNickname())
+                .memberSts(StatusType.NORMAL)
                 .memberRole(MemberRole.USER)
                 .socialType(SocialType.KAKAO)
                 .build();

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -6,3 +6,9 @@ spring:
     include:
       - db # db 설정
       - oauth2 # oauth2 설정
+
+#QueryLoggin
+#logging:
+#  level:
+#    org.hibernate.SQL: DEBUG
+#    org.hibernate.type: trace

--- a/src/test/java/com/dj/server/api/member/entity/MemberEntityTests.java
+++ b/src/test/java/com/dj/server/api/member/entity/MemberEntityTests.java
@@ -1,5 +1,6 @@
 package com.dj.server.api.member.entity;
 
+import com.dj.server.api.member.entity.enums.StatusType;
 import com.dj.server.api.member.repository.MemberRepository;
 import com.dj.server.common.dummy.member.MemberDummy;
 import org.junit.jupiter.api.BeforeEach;
@@ -83,7 +84,7 @@ public class MemberEntityTests {
 
         Member member = memberRepository.findAll().get(0); //
 
-//        assertThat(member.getMemberSts()).isEqualTo("Y");
+        assertThat(member.getMemberSts()).isEqualTo(StatusType.NORMAL);
 
     }
 

--- a/src/test/java/com/dj/server/common/dummy/member/MemberDummy.java
+++ b/src/test/java/com/dj/server/common/dummy/member/MemberDummy.java
@@ -2,6 +2,8 @@ package com.dj.server.common.dummy.member;
 
 import com.dj.server.api.member.entity.Member;
 import com.dj.server.api.member.entity.enums.MemberRole;
+import com.dj.server.api.member.entity.enums.SocialType;
+import com.dj.server.api.member.entity.enums.StatusType;
 
 /**
  *
@@ -20,6 +22,8 @@ public class MemberDummy {
     private final String memberSnsId = "kakaoId123";
     private final String memberNickName = "홍길동";
     private final MemberRole memberRole = MemberRole.USER;
+    private final SocialType socialType = SocialType.KAKAO;
+    private final StatusType statusType = StatusType.NORMAL;
 
     private static final MemberDummy instance = new MemberDummy();
 
@@ -48,9 +52,12 @@ public class MemberDummy {
 
     public Member toEntity() {
         return Member.builder()
+                .memberName(memberNickName)
                 .memberSnsId(memberSnsId)
                 .memberNickName(memberNickName)
+                .memberSts(statusType)
                 .memberRole(memberRole)
+                .socialType(socialType)
                 .build();
     }
 

--- a/src/test/java/com/dj/server/common/exception/member/MemberExceptionTest.java
+++ b/src/test/java/com/dj/server/common/exception/member/MemberExceptionTest.java
@@ -1,8 +1,11 @@
 package com.dj.server.common.exception.member;
 
 import com.dj.server.api.member.entity.Member;
+import com.dj.server.api.member.entity.enums.SocialType;
+import com.dj.server.api.member.entity.enums.StatusType;
 import com.dj.server.api.member.repository.MemberRepository;
 import com.dj.server.api.member.entity.enums.MemberRole;
+import com.dj.server.common.dummy.member.MemberDummy;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
@@ -23,6 +26,7 @@ class MemberExceptionTest {
     @Autowired
     private MemberRepository memberRepository;
 
+    private final MemberDummy memberDummy = MemberDummy.getInstance();
 
     @Test
     @Order(1)
@@ -35,7 +39,7 @@ class MemberExceptionTest {
         String nickName = "홍길동";
 
         //given
-        Long memberId = memberRepository.save(Member.builder().memberSnsId(kakaoId).memberNickName(nickName).memberRole(MemberRole.USER).build()).getMemberId();
+        Long memberId = memberRepository.save(memberDummy.toEntity()).getMemberId();
 
         //when
         //Member member = memberRepository.findById(memberId).orElseThrow(() -> new NullPointerException("회원 아이디 생성 실패"));
@@ -54,6 +58,8 @@ class MemberExceptionTest {
                                                                         .memberSnsId(kakaoId)
                                                                         .memberNickName(nickName)
                                                                         .memberRole(MemberRole.USER)
+                                                                        .memberSts(StatusType.NORMAL)
+                                                                        .socialType(SocialType.KAKAO)
                                                                         .build()));
         assertTrue(e.getCause() instanceof PersistenceException);
 

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -14,8 +14,14 @@ spring:
     properties:
       hibernate:
         format_sql: true
+    show-sql: true
 
 client-id: test # KAKAO-REST-API-KEY
 client-secret: test # 클라이언트 시크릿 기능 활성화 후 사용
 redirect-uri: 'http://localhost:8080/login/oauth2/kakao'
 authorization-grant-type: test
+
+logging:
+  level:
+    org.hibernate.SQL: DEBUG
+    org.hibernate.type: trace


### PR DESCRIPTION
# 📃 개요

MemberSts 의 값을 boolean 으로 받는방법을 찾아봅니다.


여러가지 방법을 찾고 슬랙으로의논도 해보고 하다

마지막에 생각으로 나중에 회원의 상태값을 YN 말고도

밴이라던지 휴면계정까지 확장할수도 있다 판단하여

ENUM 타입으로 변경하였습니다.

# ✏️ 추가 사항

1. StatusType Enum 이 추가되었습니다.
2. 2. MemberStatus 검증하는 테스트 코드 추가

# ✨ 변경사항

1. MemberException class 에러나던 부분 수정
2. MemberEntity 에 @DynamicUpdate 추가
3. MemberSts 를 StatusType로 변경
4. Test application.yml 설정에 쿼리 파라매터 보이는 설정 추가
5. application.yml 주석으로 쿼리 파라매터 보이는 설정 추가
6. SocialType 에서 코드로 생성자 생성하던거 롬복으로 변경
7. MemberDummy 변경된 Entity 에 맞춰 수정


