### PR TITLE
Feature/modify nick name

### DIFF
--- a/src/main/java/com/dj/server/api/member/controller/MemberController.java
+++ b/src/main/java/com/dj/server/api/member/controller/MemberController.java
@@ -16,6 +16,8 @@ import org.springframework.messaging.handler.annotation.Header;
 import org.springframework.web.bind.annotation.*;
 
 import javax.servlet.http.HttpServletResponse;
+import java.util.HashMap;
+import java.util.Map;
 
 /**
  *
@@ -59,6 +61,18 @@ public class MemberController {
     public ResponseDTO<String> signOut() {
         memberService.invalidateRefreshToken();
         return new ResponseDTO<>("로그아웃되었습니다.", "SUCCESS", HttpStatus.OK);
+    }
+
+    @ApiOperation(value = "updateNickName", notes = "닉네임 변경")
+    @ApiResponses({
+            @ApiResponse(code = 200, message = "OK"),
+            @ApiResponse(code = 404, message = "회원이 존재하지 않습니다")
+    })
+    @PatchMapping("/members/nickname")
+    public ResponseDTO<Map<String, String>> updateNickName(@RequestParam("nickname") String nickName) {
+        Map<String, String> map = new HashMap<>();
+        map.put("nickname", memberService.updateNickName(nickName));
+        return new ResponseDTO<>(map, "SUCCESS", HttpStatus.OK);
     }
 
 }

--- a/src/main/java/com/dj/server/api/member/entity/Member.java
+++ b/src/main/java/com/dj/server/api/member/entity/Member.java
@@ -81,19 +81,18 @@ public class Member {
         this.memberName = memberName;
     }
 
-
-    public void updateNickName(String nickName) {
-        this.memberNickName = nickName;
-    }
-
     public Member updateName(String name) {
         this.memberName = name;
         return this;
     }
 
-    public Member invalidateRefreshToken() {
-        this.refreshToken = null;
+    public Member updateNickName(String nickName) {
+        this.memberNickName = nickName;
         return this;
+    }
+
+    public void invalidateRefreshToken() {
+        this.refreshToken = null;
     }
 
     public void saveRefreshToken(String refreshToken) {

--- a/src/main/java/com/dj/server/api/member/model/vo/kakao/KakaoProfile.java
+++ b/src/main/java/com/dj/server/api/member/model/vo/kakao/KakaoProfile.java
@@ -29,9 +29,10 @@ public class KakaoProfile {
      * @return 신규 로그인 유저 정보
      */
     public Member toEntity() {
+        String time = String.valueOf(System.currentTimeMillis()).substring(8);
         return Member.builder()
                 .memberSnsId(String.valueOf(id))
-                .memberNickName(kakao_account.getProfile().getNickname())
+                .memberNickName(kakao_account.getProfile().getNickname() + "_" + time)
                 .memberName(kakao_account.getProfile().getNickname())
                 .memberSts(StatusType.NORMAL)
                 .memberRole(MemberRole.USER)

--- a/src/main/java/com/dj/server/api/member/repository/MemberRepository.java
+++ b/src/main/java/com/dj/server/api/member/repository/MemberRepository.java
@@ -19,4 +19,5 @@ import java.util.Optional;
 @Repository
 public interface MemberRepository extends JpaRepository<Member, Long>, MemberQueryDSLRepository {
     Optional<Member> findByMemberSnsId(String memberSnsId);
+    int countByMemberNickName(String nickname);
 }

--- a/src/main/java/com/dj/server/api/member/service/MemberService.java
+++ b/src/main/java/com/dj/server/api/member/service/MemberService.java
@@ -43,9 +43,9 @@ public class MemberService {
      * else if (신규 로그인 유저라면)
      *    카카오부터 받은 유저정보를 모두 Database에 저장합니다.
      *
-     * @created 0.0.1
      * @param profile 카카오에서 제공하는 액세스 토큰을 사용하여
      * @return 서버에서 생성한 액세스 토큰과 리프레시 토큰
+     * @since 0.0.1
      */
     @Transactional(rollbackFor = RuntimeException.class)
     public ResponseTokenDTO getGeneratedTokens(KakaoProfile profile) {
@@ -66,6 +66,7 @@ public class MemberService {
      *
      * @param member Database에 저장된 Member 정보
      * @return 서버에서 생성한 액세스 토큰과 리프레시 토큰
+     * @since 0.0.1
      */
 
     private ResponseTokenDTO createToken(Member member) {
@@ -94,6 +95,7 @@ public class MemberService {
      * @see KakaoProfile
      * @param memberSaveRequestDTO : code 카카오 인가코드, uri redirect uri
      * @return 카카오 액세스 토큰을 사용하여 카카오로부터 받은 유저의 프로필 정보
+     * @since 0.0.1
      */
     public KakaoProfile getKakaoProfile(MemberSaveRequestDTO memberSaveRequestDTO) {
         KakaoToken kakaoToken = kakaoRequest.getKakaoAccessToken(memberSaveRequestDTO.getCode(), memberSaveRequestDTO.getRedirectUri());
@@ -101,10 +103,11 @@ public class MemberService {
     }
 
     /**
-     * 액세스 토큰의 페이로드를 복호화할 때, 그 안에 포함되었던 memberId를
+     * 액세스 토큰의 페이로드를 복호화할 때, 페이로드 안에 포함되어있던 memberId를
      * JwtUtil은 저장해두고 있습니다. 그 값을 가져옵니다.
      *
      * @return member 고유 아이디
+     * @since 0.0.1
      */
     public Long getMemberId() {
         return jwtUtil.getMemberId();
@@ -118,5 +121,18 @@ public class MemberService {
     @Transactional(rollbackFor = RuntimeException.class)
     public void invalidateRefreshToken() {
         memberRepository.findById(getMemberId()).orElseThrow(() -> new MemberException(MemberCrudErrorCode.NOT_FOUND_MEMBER)).invalidateRefreshToken();
+    }
+
+    /**
+     * 회원의 닉네임을 변경하고, 변경된 닉네임을 반환합니다.
+     *
+     * @since 0.0.1
+     */
+    @Transactional(rollbackFor = RuntimeException.class)
+    public String updateNickName(String wantToChange) {
+       int count = memberRepository.countByMemberNickName(wantToChange);
+       if (count > 0) throw new MemberException(MemberCrudErrorCode.DUPLICATED_NICKNAME);
+       Member member = memberRepository.findById(getMemberId()).orElseThrow(() -> new MemberException(MemberCrudErrorCode.NOT_FOUND_MEMBER)).updateNickName(wantToChange);
+       return member.getMemberNickName();
     }
 }

--- a/src/main/java/com/dj/server/api/musiclist/controller/MusicListController.java
+++ b/src/main/java/com/dj/server/api/musiclist/controller/MusicListController.java
@@ -65,7 +65,4 @@ public class MusicListController {
         return new ResponseDTO<>(playListService.modifyMusicList(jwtUtil.getMemberId(), musicListModifyRequestDTO), "SUCCESS", HttpStatus.OK);
     }
 
-
-
-
 }

--- a/src/main/java/com/dj/server/common/exception/member/MemberCrudErrorCode.java
+++ b/src/main/java/com/dj/server/common/exception/member/MemberCrudErrorCode.java
@@ -11,7 +11,7 @@ import org.springframework.http.HttpStatus;
  */
 public enum MemberCrudErrorCode implements MemberErrorCode {
     NOT_FOUND_MEMBER(HttpStatus.NOT_FOUND, 404, "회원이 존재하지 않습니다"),
-    DUPLICATED(HttpStatus.FORBIDDEN, 403, "이 회원은 이미 존재하기 때문에 재등록할 수 없습니다.");
+    DUPLICATED_NICKNAME(HttpStatus.FORBIDDEN, 403, "이 닉네임은 이미 사용중이기 때문에 등록할 수 없습니다.");
 
     private final HttpStatus httpStatus;
     private final int httpErrorCode;


### PR DESCRIPTION
# 📃 개요

닉네임 중복체크문제 해결 및 로그인 중인 회원의 닉네임 변경로직 추가

# ✏️ 추가 사항

로그인 중인 회원이 닉네임 변경 요청했을때 처리하는 로직 구현됨

# ✨ 변경사항

신규 로그인하는 유저의 닉네임을 카카오 프로필의 닉네임 그대로 가져와 저장하던 로직에서,
닉네임_숫자 으로 저장하도록 로직을 변경하여 중복 닉네임 문제 해결 