### PR TITLE
Hotfix/locale

### DIFF
--- a/src/main/java/com/dj/server/common/filter/CountryFilter.java
+++ b/src/main/java/com/dj/server/common/filter/CountryFilter.java
@@ -58,7 +58,7 @@ public class CountryFilter implements Filter {
      * 허용할 국가 목록을 설정합니다.
      */
     private boolean isAcceptableCountry(String locale) {
-        return locale.equals("ko_KR") || locale.equals("en_US")  || locale.equals("en");
+        return locale.equals("ko_KR") || locale.equals("ko") || locale.equals("en_US") || locale.equals("en");
     }
 
     /**


### PR DESCRIPTION
# 📃 개요

핫픽스: 로케일 검증 로직 변경

# ✨ 변경사항

로케일 검증 시 국가 정보와 언어를 중복해서 비교하는 부분 수정

```
return (locale.toString().equals("ko") || locale.toString().equals("ko_KR") 
```
to
```
switch(locale.getLanguage().toLowerCase())
    case "ko":
       return true
    default:
       return false
```